### PR TITLE
ci: use reusable Doxygen GH Pages workflow from makers-devops

### DIFF
--- a/.github/workflows/doxygen_gh.yml
+++ b/.github/workflows/doxygen_gh.yml
@@ -1,0 +1,16 @@
+name: Doxygen GH
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: write
+
+jobs:
+  call-doxygen-gh-pages:
+    uses: Infineon/makers-devops/.github/workflows/doxygen_gh_pages.yml@main
+    permissions:
+      contents: write


### PR DESCRIPTION
## Summary

Adds a Doxygen GitHub Pages workflow that delegates to the centralized reusable workflow maintained in [Infineon/makers-devops](https://github.com/Infineon/makers-devops).

## Changes

- `.github/workflows/doxygen_gh.yml`: New file — calls `Infineon/makers-devops/.github/workflows/doxygen_gh_pages.yml@main` to build Doxygen docs and deploy to GitHub Pages on every push or PR targeting `master`

## Motivation

- **Consistency**: Aligns this repo with the standard Doxygen CI setup used across Infineon Arduino libraries
- **Maintainability**: Centralizes the Doxygen build and deployment logic in a single reusable workflow
- **Automation**: Ensures GitHub Pages documentation is kept up to date automatically